### PR TITLE
Move scaling inside plot generation

### DIFF
--- a/PlotScript.m
+++ b/PlotScript.m
@@ -6,7 +6,4 @@ DATA_FILE = "defaultSimulationData.mat";
 
 load("data/" + DATA_FILE, 'p', 'K', 'KsqrtlogK', 'MND');
 
-% Compute least squares constant
-scale = leastSquares(transpose(KsqrtlogK), transpose(MND));
-
-generatePlots(p, K, scale*KsqrtlogK, MND, FILE_NAME, LOG_LOG);
+generatePlots(p, K, KsqrtlogK, MND, FILE_NAME, LOG_LOG);

--- a/generatePlots.m
+++ b/generatePlots.m
@@ -1,25 +1,28 @@
 function generatePlots(p, K, KsqrtlogK, MND, fileName, loglogPlot)
     PLOT_DIRECTORY = "plots/";
     prefix = PLOT_DIRECTORY + fileName;
-    Kscale = leastSquares(transpose(K), transpose(MND));
+    
+    % compute least squares constants
+    scaledK = K*leastSquares(transpose(K), transpose(MND));
+    scaledKsqrtlogK = KsqrtlogK*leastSquares(transpose(KsqrtlogK), transpose(MND));
     
     if loglogPlot
-        loglog(p, MND, "r", p, KsqrtlogK, "b--", p, K*Kscale, "b:");
+        loglog(p, MND, "r", p, scaledKsqrtlogK, "b--", p, scaledK, "b:");
         xlabel('p');
         legend('MND(p)', 'c x K(p) x sqrt(log K(p))', 'c'' x K(p)');
         savefig(prefix + "_p_loglog.fig");
         
-        loglog(K, MND, "r",K, KsqrtlogK, "b--", K, K*Kscale, "b:");
+        loglog(K, MND, "r",K, scaledKsqrtlogK, "b--", K, scaledK, "b:");
         xlabel('K');
         legend('MND(K)','c x K x sqrt(log K)', 'c'' x K');
         savefig(prefix + "_K_loglog.fig");
     else
-        plot(p, MND, "r", p, KsqrtlogK, "b--", p, K*Kscale, "b:");
+        plot(p, MND, "r", p, scaledKsqrtlogK, "b--", p, scaledK, "b:");
         xlabel('p');
         legend('MND(p)','c x K(p) x sqrt(log K(p))','c'' x K(p)');
         savefig(prefix + "_p.fig");
         
-        plot(K, MND, "r", K, KsqrtlogK, "b--", K, K*Kscale, "b:");
+        plot(K, MND, "r", K, scaledKsqrtlogK, "b--", K, scaledK, "b:");
         xlabel('K');
         legend('MND(K)','c x K x sqrt(log K)','c'' x K');
         savefig(prefix + "_K.fig");

--- a/leastSquares.m
+++ b/leastSquares.m
@@ -3,7 +3,6 @@ function [coeff] = leastSquares(design,response)
 %   'response' must be a column vector. The number of columns of 'design'
 %   should be the number of predictor variables; correspondingly, the
 %   number of rows is the sample size.
-
-coeff = ((transpose(design)*design)\transpose(design))*response;
+    coeff = ((transpose(design)*design)\transpose(design))*response;
 end
 

--- a/simulateDeviation.m
+++ b/simulateDeviation.m
@@ -5,11 +5,8 @@ function simulateDeviation(numPoints, rightEndpoint, samples, resultFileName, us
     % save the data
     save("data/" + resultFileName, 'p', 'K', 'KsqrtlogK', 'MND');
     
-    % compute least squares constant (used to scale KsqrtlogK)
-    scale = leastSquares(transpose(KsqrtlogK), transpose(MND));
-    
     % plot the data
-    plotData(p, K, KsqrtlogK, MND, scale, numPoints, rightEndpoint, samples);
+    plotData(p, K, KsqrtlogK, MND, numPoints, rightEndpoint, samples);
 end
 
 function [p, K, KsqrtlogK, MND] = generateData(numPoints, rightEndpoint, samples, useCustomSet, customSetFile)
@@ -35,10 +32,10 @@ function [p, K, KsqrtlogK, MND] = generateData(numPoints, rightEndpoint, samples
     MND = arrayfun(MNDFn, p); 
 end
 
-function plotData(p, K, KsqrtlogK, MND, scale, numPoints, rightEndpoint, samples)
+function plotData(p, K, KsqrtlogK, MND, numPoints, rightEndpoint, samples)
     % plot MND and K*sqrt(log K) for reference
     prefixEndpoint =  strrep(string(rightEndpoint), '.', ',');
     prefix = numPoints + "_pts_" + samples + "_samples_" + prefixEndpoint + "_endpoint";
 
-    generatePlots(p, K, scale*KsqrtlogK, MND, prefix, true);
+    generatePlots(p, K, KsqrtlogK, MND, prefix, true);
 end


### PR DESCRIPTION
Move the least-squares scaling of KsqrtlogK inside plot generation, in order to be consistent with the scaling of K and reduce duplication.